### PR TITLE
fix: corrige erro no upload de imagem no leitor de QR Code

### DIFF
--- a/gestao_simples/views/qrcode/view.py
+++ b/gestao_simples/views/qrcode/view.py
@@ -117,10 +117,8 @@ class QRCodeView:
         try:
             # Corrige orientação e salva
             image = self.qrcode_service.correct_image_orientation(image)
-            save_path = self.qrcode_service.save_image(image, source_type)
             expander = st.expander("Ver imagem")
             expander.image(image, caption="Imagem QR Code", use_container_width=True)
-            expander.success(f"Imagem salva em {save_path}")
 
             # Processa imagem baseado na fonte
             if source_type == "uploaded":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gestao-simples"
-version = "0.1.0"
+version = "0.1.1"
 description = "Sistema de gestão simplificado para pequenas empresas, que permite a leitura de cupons fiscais via QRCode, coleta automática de dados da SEFAZ-MS através de web scraping e armazenamento seguro em um banco de dados MySQL."
 authors = [
     {name = "WolkerDias",email = "wolker.sd@hotmail.com"}


### PR DESCRIPTION
### O que foi feito
- Corrigido erro que impedia leitura de imagens no leitor de QR Code

### Como testar
- Vá até a página Leitor QR Code
- Faça upload de uma imagem válida e verifique se o código é lido corretamente

### Checklist
- [x] Bug corrigido
- [x] Testado manualmente
- [x] Versionado com poetry